### PR TITLE
汉化了一下 xaero 地图标点分享

### DIFF
--- a/kubejs/server_scripts/xaerosmap.js
+++ b/kubejs/server_scripts/xaerosmap.js
@@ -1,0 +1,27 @@
+PlayerEvents.decorateChat(event => {
+  if (event.message.trim().toLowerCase().includes('xaero-waypoint')) {
+    let msg = '' + event.message
+    let user_name = event.getUsername()
+    let {x, y, z, dimension, biomeId} = event.player.getBlock()
+    let dimensionKey = ('' + dimension).replace(':','$')
+    let biomeKey = ('' + biomeId).replace(':','.')
+    
+//     /xaero_waypoint_add:Cave:C:468:65:-397:11:false:0:Internal-dim%blue-skies$everbright-waypoints
+//     xaero-waypoint:地牢:地:3:93:-922:15:false:0:Internal-dim%blue-skies$everbright-waypoints
+    
+    let add_command = `/xaero_waypoint_add:${user_name}分享的地点:${user_name.slice(0,1).toUpperCase()}:${x}:${y}:${z}:4:false:0:Internal-dim%${dimensionKey}-waypoints`
+    let base = Component.string('')
+    let texts = [
+      Component.string('分享了一个位置：').noColor(),
+      Component.green('[').bold(),
+      Component.translate(`biome.${biomeKey}`).underlined().green(),
+      Component.gray(`(x: ${x} y: ${y} z: ${z})`),
+      Component.green(']').bold(),
+    ]
+    texts.forEach(ele => base.append(ele))
+    base.clickRunCommand(add_command).hover('' + dimension + ' - ' + biomeId + '\n点击添加路径点')
+    
+    event.setMessage(base)
+  }
+  
+})


### PR DESCRIPTION
实在受不了 Xaero 地图这个标点分享灰不拉几的
自己写了个汉化
原理是用 kubejs 的 decorateChat 直接修改消息

效果（点击可以直接打开创建标点的那个界面）：
![image](https://github.com/user-attachments/assets/275dab72-65b0-407d-a640-749110dd3774)
![image](https://github.com/user-attachments/assets/73fadd5b-d42f-4988-ba8c-f173c29bc4a8)
