### PR TITLE
汉化了一下 xaero's map 的标点分享

### DIFF
--- a/kubejs/server_scripts/xaerosmap.js
+++ b/kubejs/server_scripts/xaerosmap.js
@@ -1,0 +1,32 @@
+PlayerEvents.decorateChat(event => {
+  if (event.message.trim().toLowerCase().includes('xaero-waypoint')) {
+    let msg = '' + event.message
+    
+    let parse = msg.split(':')
+    let name = parse[1]
+    let x = parse[3]
+    let y = parse[4]
+    let z = parse[5]
+    let dim = parse[9]
+    
+    // 判断是否模组维度
+	let dim_key = (dim.includes('$') ? dim.replace('Internal-','dimension.') : dim.replace('Internal-','dimension.minecraft.')).replace('-waypoints','').replace('dim%','').replace('$','.')
+    //let dim_translate = Component.translate(dim_key)
+    // ↑ 找不到翻译键名 mc原版自带的维度是有翻译的 如果能找到翻译键名就替换上去好了
+    
+     ///xaero_waypoint_add:Cave:C:468:65:-397:11:false:0:Internal-dim%blue-skies$everbright-waypoints
+     //xaero-waypoint:地牢:地:3:93:-922:15:false:0:Internal-dim%blue-skies$everbright-waypoints
+    
+    let add_command = `/xaero_waypoint_add:${name}:${name.slice(0,1).toUpperCase()}:${x}:${y}:${z}:4:false:0:${dim}`
+    let base = Component.string('')
+    let texts = [
+      Component.string('分享了一个位置：').noColor(),
+      //dim_translate.green().underlined(),
+      Component.green(`[x: ${x} y: ${y} z: ${z} @ ${dim_key.split('.')[2]}]`).underlined(),
+    ]
+    texts.forEach(ele => base.append(ele))
+    //base.clickRunCommand(add_command).hover('' + dim_translate.getString() + '\n点击添加路径点')
+    base.clickRunCommand(add_command).hover('点击添加路径点')
+    event.setMessage(base)
+  }
+})


### PR DESCRIPTION
受不了 xaero 标点分享灰不拉几的还不能汉化

效果：
![image](https://github.com/user-attachments/assets/65a5d829-421a-44b8-85e5-ec7c80792db0)

翻了半小时没翻到维度的翻译键名（mc 原版的维度翻译键名是 `minecraft.overworld`/`minecraft.the_end`/`minecraft.nether`，但是模组的维度不知道是不存在翻译还是不是这个写法）
倒是有个骚想法
 > 已知所有维度都有传送门，且传送门方块为维度id后接 `_portal`，这个传送门方块是有翻译的，那我只要去掉后面的后缀不就好了！（但是太不优雅了）


