### PR TITLE
添加成就：盲目痴愚

### DIFF
--- a/kubejs/data/path_of_truth/advancements/blind_idiot.json
+++ b/kubejs/data/path_of_truth/advancements/blind_idiot.json
@@ -1,0 +1,29 @@
+{
+  "parent":"path_of_truth:root",
+  "display": {
+    "icon": {
+      "item": "botania:white_petal"
+    },
+    "title": {
+      "translate": "盲目痴愚"
+    },
+    "description": {
+      "translate": "阿撒托斯所造之物只在祂的梦中存在"
+    },
+    "frame": "challenge",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": true
+  },
+  "criteria": {
+    "r": {
+      "trigger": "minecraft:impossible"
+    }
+  },
+  "requirements": [
+    [
+      "r"
+    ]
+  ],
+  "sends_telemetry_event": false
+}

--- a/kubejs/server_scripts/advancements.js
+++ b/kubejs/server_scripts/advancements.js
@@ -47,3 +47,24 @@ let grantAdvancement = (player, advancement, mode) => player.server.runCommandSi
    if (count >= 30) { grantAdvancement(player, "path_of_truth:water_wheel", "only"); }
  }));
  
+ItemEvents.dropped("#forge:seeds", event => {
+  let {player} = event;
+  // kubejs 检测这个事件的触发条件是主手物品而不是丢出物品
+  // 也就是说，我主手拿着种子，打开背包丢出任何物品都会触发这个事件
+  // 所以这里加一个过滤
+  if (!event.item.hasTag("forge:seeds")) { return }
+  // 假人与非玩家投掷不计入
+  if (!player.isPlayer() || player.isFake()) { return }
+  // 最远也就扔 4 格，这里设个 8 吧
+  let target = player.rayTrace(8);
+  if(target.type == "block") {
+    // 检测变种花药台
+    if (!target.block.id.startsWith("botania:apothecary")) { return }
+    let ap_items = target.block.entityData['Items'];
+    if (ap_items.length < 4) { return }
+
+    let mystical_white_petal_count = ap_items.filter(item => item.id == "botania:white_petal").length;
+    // 如果有其它含有四个白色花瓣的配方同样会触发，防止以后有之类配方，加个判断
+    if (mystical_white_petal_count == 4 && ap_items.length == 4) { grantAdvancement(player,"path_of_truth:blind_idiot","only"); }
+  }
+});


### PR DESCRIPTION
触发条件：花药台中有四个白色神秘花瓣的情况下，看着花药台丢入任意含有`forge:seeds`标签的物品
（原版植物魔法合成白雏菊的方式）

由于不看着花药台也能把种子丢进去，但也没有别的好方式判断东西有没有丢到花药台里。所以逻辑是这样的：当玩家发现把种子丢进去合不出来的时候有大概率会把刚刚丢进去的种子拿出来，然后看着花药台再丢一次。

_（其实有更好的方式，当玩家往花药台丢东西的时候会触发一个同步过程，简略来说就是在花药台的服务端被丢入物品时会进行一个数据包的广播，来实现同步，但是很麻烦，懒得这么写）_
